### PR TITLE
Don't fail if Asterisk and asterisk_click2dial aren't installed

### DIFF
--- a/asterisk_click2dial/asterisk_click2dial.py
+++ b/asterisk_click2dial/asterisk_click2dial.py
@@ -24,9 +24,13 @@ from openerp.tools.translate import _
 import logging
 # Lib for phone number reformating -> pip install phonenumbers
 import phonenumbers
-# Lib py-asterisk from http://code.google.com/p/py-asterisk/
-# -> pip install py-Asterisk
-from Asterisk import Manager
+
+try:
+    # Lib py-asterisk from http://code.google.com/p/py-asterisk/
+    # -> pip install py-Asterisk
+    from Asterisk import Manager
+except ImportError:
+    Manager = None
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
When adding telephony to Odoo's addons path, it will fail if Asterisk isn't installed.
Since Asterisk is declared as an external dependency, it cannot be installed in this case.
However, odoo will still try to execute code imported in `__init__.py` even if the module isn't installed.

Hiding the ImportError is important for users who do intend to install asterisk_click2dial but need the modules included in this repo.
