### PR TITLE
FIX: clear field when number not set rather than leaving previous value

### DIFF
--- a/base_phone/static/src/js/phone_widget.js
+++ b/base_phone/static/src/js/phone_widget.js
@@ -21,51 +21,55 @@ openerp.base_phone = function (instance) {
                 var self = this;
                 var phone_num = this.get('value');
                 //console.log('BASE_PHONE phone_num = %s', phone_num);
+                var href = '#';
+                var href_text = '';
                 if (phone_num) {
-                    this.$el.find('a.oe_form_uri')
-                        .attr('href', 'tel:' + phone_num)
-                        .text(formatInternational('', phone_num) || '');
+                  href = 'tel:' + phone_num;
+                  href_text = formatInternational('', phone_num) || '';
                 }
+                this.$el.find('a.oe_form_uri').attr('href', href).text(href_text);
+                var click2dial_text = '';
                 if (phone_num && !this.options.dial_button_invisible) {
-                    this.$el.find('#click2dial')
-                        .text(phone_num && _t('Dial') || '')
-                        .on('click', function(ev) {
-                            self.do_notify(
-                                _t('Click2dial started'),
-                                _t('Unhook your ringing phone'));
-                            var arg = {
-                                'phone_number': phone_num,
-                                'click2dial_model': self.view.dataset.model,
-                                'click2dial_id': self.view.datarecord.id};
-                            self.rpc('/base_phone/click2dial', arg).done(function(r) {
-                                //console.log('Click2dial r=%s', JSON.stringify(r));
-                                if (r === false) {
-                                    self.do_warn("Click2dial failed");
-                                } else if (typeof r === 'object') {
-                                    self.do_notify(
-                                        _t('Click2dial successfull'),
-                                        _t('Number dialed:') + ' ' + r.dialed_number);
-                                    if (r.action_model) {
-                                        var context = {};
-                                        if (self.view.dataset.model == 'res.partner') {
-                                            context = {
-                                                'partner_id': self.view.datarecord.id};
-                                            }
-                                        var action = {
-                                            name: r.action_name,
-                                            type: 'ir.actions.act_window',
-                                            res_model: r.action_model,
-                                            view_mode: 'form',
-                                            views: [[false, 'form']],
-                                            target: 'new',
-                                            context: context,
-                                            };
-                                        instance.client.action_manager.do_action(action);
-                                    }
-                                }
-                            });
-                        });
+                  click2dial_text = _t('Dial');
                 }
+                this.$el.find('#click2dial')
+                    .text(click2dial_text)
+                    .on('click', function(ev) {
+                        self.do_notify(
+                            _t('Click2dial started'),
+                            _t('Unhook your ringing phone'));
+                        var arg = {
+                            'phone_number': phone_num,
+                            'click2dial_model': self.view.dataset.model,
+                            'click2dial_id': self.view.datarecord.id};
+                        self.rpc('/base_phone/click2dial', arg).done(function(r) {
+                            //console.log('Click2dial r=%s', JSON.stringify(r));
+                            if (r === false) {
+                                self.do_warn("Click2dial failed");
+                            } else if (typeof r === 'object') {
+                                self.do_notify(
+                                    _t('Click2dial successfull'),
+                                    _t('Number dialed:') + ' ' + r.dialed_number);
+                                if (r.action_model) {
+                                    var context = {};
+                                    if (self.view.dataset.model == 'res.partner') {
+                                        context = {
+                                            'partner_id': self.view.datarecord.id};
+                                        }
+                                    var action = {
+                                        name: r.action_name,
+                                        type: 'ir.actions.act_window',
+                                        res_model: r.action_model,
+                                        view_mode: 'form',
+                                        views: [[false, 'form']],
+                                        target: 'new',
+                                        context: context,
+                                        };
+                                    instance.client.action_manager.do_action(action);
+                                }
+                            }
+                        });
+                    });
             }
         },
         on_button_clicked: function() {
@@ -113,4 +117,4 @@ openerp.base_phone = function (instance) {
         return res;
     };
 
-}
+};


### PR DESCRIPTION
Fix for switching between contact via form view showing the previous contact's phone number if this contact does not have one set.
