### PR TITLE
new: pkg: adds requirements.txt to explicit dependencies 

### DIFF
--- a/asterisk_click2dial/requirements.txt
+++ b/asterisk_click2dial/requirements.txt
@@ -1,0 +1,2 @@
+phonenumbers
+py-Asterisk

--- a/base_phone/requirements.txt
+++ b/base_phone/requirements.txt
@@ -1,0 +1,1 @@
+phonenumbers


### PR DESCRIPTION
This will ease scripted installations, and make obvious some less obvious information (that the external_depedency for "Asterisk" is named "py-Asterisk" for example).

I tried to avoid repeating information by sourcing the `requirements.txt` file in the `__openerp__.py`, but this is not possible for 2 reasons:
- `__openerp__.py` is parsed by safe_eval which doesn't include the builtin `open`.
- external_dependencies in openerp check that names are importable module, and `requirements.txt` list pypi package name. This is quite different. For asterisk, the module is "Asterisk" and it's pypi package name is `py-Asterisk`.
