### PR TITLE
Override name_get for hr_applicant so that applicant name for cid lookup is returned

### DIFF
--- a/hr_recruitment_phone/hr_recruitment_phone.py
+++ b/hr_recruitment_phone/hr_recruitment_phone.py
@@ -42,3 +42,19 @@ class hr_applicant(orm.Model):
             cr, uid, ids, vals, context=context)
         return super(hr_applicant, self).write(
             cr, uid, ids, vals_reformated, context=context)
+
+    def name_get(self, cr, uid, ids, context=None):
+        if context is None:
+            context = {}
+        if context.get('callerid'):
+            res = []
+            if isinstance(ids, (int, long)):
+                ids = [ids]
+            for applicant in self.browse(cr, uid, ids, context=context):
+                name = applicant.partner_name
+                if applicant.state not in ['done', 'cancel']:
+                    res.append((applicant.id, name))
+            return res
+        else:
+            return super(hr_applicant, self).name_get(
+                cr, uid, ids, context=context)

--- a/hr_recruitment_phone/hr_recruitment_phone.py
+++ b/hr_recruitment_phone/hr_recruitment_phone.py
@@ -43,6 +43,20 @@ class hr_applicant(orm.Model):
         return super(hr_applicant, self).write(
             cr, uid, ids, vals_reformated, context=context)
 
+    # The only reason this is overloaded her as applicant.name is the
+    # position. This is what base_phone.py:name_get will return.
+    # It makes more sense in this context to return the applicant's name.
+    # This code appears weird as it returns [] in the cases:
+    # 1) hired - done or 2) refused - cancel.
+    # This is done so that an employees record is used instead of the
+    # applicant record. The following (cancel) applies here as well.
+    # It is done for cancel so that an applicant who is refused doesn't
+    # cause problems if that number is reassigned to another entity in the
+    # future or the same person applies for the same or different position
+    # in the future. We cannot call super name_get in these cases as it will
+    # still return the position the person applied for and the pop-up
+    # functionality would then pull up this record. Both of these are
+    # undesirable.
     def name_get(self, cr, uid, ids, context=None):
         if context is None:
             context = {}


### PR DESCRIPTION
Override name_get for hr_applicant so that applicant name and not position is what is returned by caller ID lookup.
Do not return any information if applicant is hired or refused as this information is either useless or exists elsewhere.

Possible enhancement:
- Create three global settings: allow cid for hired applicant, allow cid for refused applicant, show title and not applicant name for cid.
