### PR TITLE
[FIX] set countrycode in upper case to avoid error with the lib phonenumbers

### DIFF
--- a/base_phone/base_phone.py
+++ b/base_phone/base_phone.py
@@ -90,7 +90,7 @@ class PhoneCommon(models.AbstractModel):
                     init_value = vals.get(field)
                     try:
                         res_parse = phonenumbers.parse(
-                            vals.get(field), countrycode)
+                            vals.get(field), countrycode.upper())
                         vals[field] = phonenumbers.format_number(
                             res_parse, phonenumbers.PhoneNumberFormat.E164)
                         if init_value != vals[field]:


### PR DESCRIPTION
Hello, 

The library phonnumbers only accepts upper case country code. Set the countrycode variable in upper case can avoid some problems when reformating.
