### PR TITLE
[FIX] Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,10 @@ env:
   matrix:
   - LINT_CHECK="1"
   - TRANSIFEX="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo"
-  - TESTS="1" ODOO_REPO="OCA/OCB"
+  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="asterisk_click2dial,asterisk_click2dial_crm"
+  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="asterisk_click2dial,asterisk_click2dial_crm"
+  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="asterisk_click2dial,asterisk_click2dial_crm"
+  - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="asterisk_click2dial,asterisk_click2dial_crm"
 
 virtualenv:
   system_site_packages: true

--- a/base_phone/base_phone.py
+++ b/base_phone/base_phone.py
@@ -198,18 +198,13 @@ class PhoneCommon(models.AbstractModel):
     def _get_phone_fields(self):
         '''Returns a dict with key = object name
         and value = list of phone fields'''
-        models = self.env['ir.model'].search([('osv_memory', '=', False)])
         res = []
-        for model in models:
-            senv = False
-            try:
-                senv = self.env[model.model]
-            except:
-                continue
+        for model_name in self.env.registry:
+            senv = self.env[model_name]
             if (
-                    '_phone_fields' in dir(senv) and
+                    getattr(senv, '_phone_fields', None) and
                     isinstance(senv._phone_fields, list)):
-                res.append(model.model)
+                res.append(model_name)
         return res
 
     def click2dial(self, cr, uid, erp_number, context=None):

--- a/base_phone/base_phone.py
+++ b/base_phone/base_phone.py
@@ -103,10 +103,12 @@ class PhoneCommon(models.AbstractModel):
                         #    by a user via the Web interface
                         # logger is usefull when the record is created/written
                         #    via the webservices
-                        _logger.error(
-                            "Cannot reformat the phone number '%s' to "
-                            "international format with region=%s"
-                            % (vals.get(field), countrycode))
+                        # Just don't generate this error message during testing
+                        if not context.get('yml_test'):
+                            _logger.error(
+                                "Cannot reformat the phone number '%s' to "
+                                "international format with region=%s"
+                                % (vals.get(field), countrycode))
                         if context.get('raise_if_phone_parse_fails'):
                             raise Warning(
                                 _("Cannot reformat the phone number '%s' to "

--- a/base_phone/test/phonenum.yml
+++ b/base_phone/test/phonenum.yml
@@ -16,7 +16,7 @@
 -
   Write invalid phone number
 -
-  !record {model: res.partner, id: partner3}:
+  !record {model: res.partner, id: partner3, context: {"yml_test": True}}:
     name: Jean Badphone
     phone: 42
 -


### PR DESCRIPTION
Conversion of a phone number leads to an exception when triggered through the interface, or an error message otherwise. If the error message is not suppressed, travis will always reject the result. This does not undermine the test as the test validates that the phone number in case has not been modified.
