### PR TITLE
Less verbose logs

### DIFF
--- a/base_phone/base_phone.py
+++ b/base_phone/base_phone.py
@@ -78,9 +78,9 @@ class PhoneCommon(models.AbstractModel):
                     countrycode = user.company_id.country_id.code
                 else:
                     _logger.warning(
-                        _("You should set a country on the company '%s' "
-                            "to allow the reformat of phone numbers")
-                        % user.company_id.name)
+                        "You should set a country on the company '%s' "
+                        "to allow the reformat of phone numbers",
+                        user.company_id.name)
                     countrycode = None
                 # with country code = None, phonenumbers.parse() will work
                 # with phonenumbers formatted in E164, but will fail with
@@ -95,8 +95,8 @@ class PhoneCommon(models.AbstractModel):
                             res_parse, phonenumbers.PhoneNumberFormat.E164)
                         if init_value != vals[field]:
                             _logger.debug(
-                                "%s initial value: '%s' updated value: '%s'"
-                                % (field, init_value, vals[field]))
+                                "%s initial value: '%s' updated value: '%s'",
+                                field, init_value, vals[field])
                     except Exception, e:
                         # I do BOTH logger and raise, because:
                         # raise is usefull when the record is created/written

--- a/base_phone/base_phone.py
+++ b/base_phone/base_phone.py
@@ -77,7 +77,7 @@ class PhoneCommon(models.AbstractModel):
                 if user.company_id.country_id:
                     countrycode = user.company_id.country_id.code
                 else:
-                    _logger.error(
+                    _logger.warning(
                         _("You should set a country on the company '%s' "
                             "to allow the reformat of phone numbers")
                         % user.company_id.name)
@@ -94,7 +94,7 @@ class PhoneCommon(models.AbstractModel):
                         vals[field] = phonenumbers.format_number(
                             res_parse, phonenumbers.PhoneNumberFormat.E164)
                         if init_value != vals[field]:
-                            _logger.info(
+                            _logger.debug(
                                 "%s initial value: '%s' updated value: '%s'"
                                 % (field, init_value, vals[field]))
                     except Exception, e:


### PR DESCRIPTION
Logs are cluttered by 'initial value...updated value' and it is really not
necessary to log that using a 'info' level.
The 'error' log level is excessive for the missing country.

If someone really wants to display the original and updated values, there still
is the possibility to use a `--log-handler=openerp.addons.base_phone:DEBUG`.
