### PR TITLE
8.0 avoid crash in report caused by the failure to reformat a phone number

### DIFF
--- a/base_phone/report_sxw_format.py
+++ b/base_phone/report_sxw_format.py
@@ -44,17 +44,20 @@ def format(
     if self.pool.get('base.phone.installed') and phone and text:
         # text should already be in E164 format, so we don't have
         # to give a country code to phonenumbers.parse()
-        phone_number = phonenumbers.parse(text)
-        if phone_format == 'international':
-            res = phonenumbers.format_number(
-                phone_number, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
-        elif phone_format == 'national':
-            res = phonenumbers.format_number(
-                phone_number, phonenumbers.PhoneNumberFormat.NATIONAL)
-        elif phone_format == 'e164':
-            res = phonenumbers.format_number(
-                phone_number, phonenumbers.PhoneNumberFormat.E164)
-        else:
+        try:
+            phone_number = phonenumbers.parse(text)
+            if phone_format == 'international':
+                res = phonenumbers.format_number(
+                    phone_number, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
+            elif phone_format == 'national':
+                res = phonenumbers.format_number(
+                    phone_number, phonenumbers.PhoneNumberFormat.NATIONAL)
+            elif phone_format == 'e164':
+                res = phonenumbers.format_number(
+                    phone_number, phonenumbers.PhoneNumberFormat.E164)
+            else:
+                res = text
+        except:
             res = text
     else:
         res = format_original(self, text, oldtag=oldtag)


### PR DESCRIPTION
If a "phone"  field is not in E.164 format (because it was not reformatted by the wizard for example), then phonenumbers.parse(phone) inside the format() method of the report will raise an exception, which will cause a failure to generate the report.

This PR fixes this.
