### PR TITLE
[FIX] crm.phonecall. default in team_id should be a browse 'crm.team', not an int

### DIFF
--- a/crm_phone/crm_phone.py
+++ b/crm_phone/crm_phone.py
@@ -71,7 +71,8 @@ class CrmPhonecall(models.Model):
         default=lambda self: self.env.user)
     team_id = fields.Many2one(
         'crm.team', string='Sales Team', track_visibility='onchange',
-        default=lambda self: self.env['crm.team']._get_default_team_id())
+        default=lambda self: self.env['crm.team'].browse(
+            self.env['crm.team']._get_default_team_id()))
     partner_id = fields.Many2one(
         'res.partner', string='Contact', ondelete='cascade')
     partner_phone = Phone(string='Phone', partner_field='partner_id')


### PR DESCRIPTION
Otherwise error occurs when loading the module 'crm.phonecall' with message "AttributeError: 'int' object has no attribute 'id'"
