### PR TITLE
8.0 Import phonenumbers protected by try/except

### DIFF
--- a/base_phone/base_phone.py
+++ b/base_phone/base_phone.py
@@ -24,7 +24,10 @@ from openerp.tools.safe_eval import safe_eval
 from openerp.exceptions import Warning
 import logging
 # Lib for phone number reformating -> pip install phonenumbers
-import phonenumbers
+try:
+    import phonenumbers
+except ImportError:
+    logger.warning('Cannot import phonenumbers')
 
 _logger = logging.getLogger(__name__)
 

--- a/base_phone/base_phone.py
+++ b/base_phone/base_phone.py
@@ -27,7 +27,7 @@ import logging
 try:
     import phonenumbers
 except ImportError:
-    logger.warning('Cannot import phonenumbers')
+    logger.debug('Cannot import phonenumbers')
 
 _logger = logging.getLogger(__name__)
 

--- a/base_phone/base_phone.py
+++ b/base_phone/base_phone.py
@@ -23,13 +23,14 @@ from openerp import models, fields, api, _
 from openerp.tools.safe_eval import safe_eval
 from openerp.exceptions import Warning
 import logging
+
+_logger = logging.getLogger(__name__)
+
 # Lib for phone number reformating -> pip install phonenumbers
 try:
     import phonenumbers
 except ImportError:
-    logger.debug('Cannot import phonenumbers')
-
-_logger = logging.getLogger(__name__)
+    _logger.debug('Cannot import phonenumbers')
 
 
 class PhoneCommon(models.AbstractModel):

--- a/base_phone/report_sxw_format.py
+++ b/base_phone/report_sxw_format.py
@@ -21,7 +21,10 @@
 
 from openerp.osv import orm
 from openerp.report import report_sxw
-import phonenumbers
+try:
+    import phonenumbers
+except ImportError:
+    logger.warning('Cannot import phonenumbers')
 
 
 class base_phone_installed(orm.AbstractModel):

--- a/base_phone/report_sxw_format.py
+++ b/base_phone/report_sxw_format.py
@@ -24,7 +24,7 @@ from openerp.report import report_sxw
 try:
     import phonenumbers
 except ImportError:
-    logger.warning('Cannot import phonenumbers')
+    logger.debug('Cannot import phonenumbers')
 
 
 class base_phone_installed(orm.AbstractModel):

--- a/base_phone/report_sxw_format.py
+++ b/base_phone/report_sxw_format.py
@@ -21,10 +21,14 @@
 
 from openerp.osv import orm
 from openerp.report import report_sxw
+import logging
+
+_logger = logging.getLogger(__name__)
+
 try:
     import phonenumbers
 except ImportError:
-    logger.debug('Cannot import phonenumbers')
+    _logger.debug('Cannot import phonenumbers')
 
 
 class base_phone_installed(orm.AbstractModel):

--- a/base_phone/wizard/number_not_found.py
+++ b/base_phone/wizard/number_not_found.py
@@ -25,7 +25,7 @@ import logging
 try:
     import phonenumbers
 except ImportError:
-    logger.warning('Cannot import phonenumbers')
+    logger.debug('Cannot import phonenumbers')
 
 _logger = logging.getLogger(__name__)
 

--- a/base_phone/wizard/number_not_found.py
+++ b/base_phone/wizard/number_not_found.py
@@ -22,12 +22,13 @@
 from openerp.osv import orm, fields
 from openerp.tools.translate import _
 import logging
+
+_logger = logging.getLogger(__name__)
+
 try:
     import phonenumbers
 except ImportError:
-    logger.debug('Cannot import phonenumbers')
-
-_logger = logging.getLogger(__name__)
+    _logger.debug('Cannot import phonenumbers')
 
 
 class number_not_found(orm.TransientModel):

--- a/base_phone/wizard/number_not_found.py
+++ b/base_phone/wizard/number_not_found.py
@@ -22,7 +22,10 @@
 from openerp.osv import orm, fields
 from openerp.tools.translate import _
 import logging
-import phonenumbers
+try:
+    import phonenumbers
+except ImportError:
+    logger.warning('Cannot import phonenumbers')
 
 _logger = logging.getLogger(__name__)
 

--- a/crm_phone/wizard/create_crm_phonecall.py
+++ b/crm_phone/wizard/create_crm_phonecall.py
@@ -21,10 +21,14 @@
 ##############################################################################
 
 from openerp import models, api, _
+import logging
+
+_logger = logging.getLogger(__name__)
+
 try:
     import phonenumbers
 except ImportError:
-    logger.debug('Cannot import phonenumbers')
+    _logger.debug('Cannot import phonenumbers')
 
 
 class wizard_create_crm_phonecall(models.TransientModel):

--- a/crm_phone/wizard/create_crm_phonecall.py
+++ b/crm_phone/wizard/create_crm_phonecall.py
@@ -21,7 +21,10 @@
 ##############################################################################
 
 from openerp import models, api, _
-import phonenumbers
+try:
+    import phonenumbers
+except ImportError:
+    logger.warning('Cannot import phonenumbers')
 
 
 class wizard_create_crm_phonecall(models.TransientModel):

--- a/crm_phone/wizard/create_crm_phonecall.py
+++ b/crm_phone/wizard/create_crm_phonecall.py
@@ -24,7 +24,7 @@ from openerp import models, api, _
 try:
     import phonenumbers
 except ImportError:
-    logger.warning('Cannot import phonenumbers')
+    logger.debug('Cannot import phonenumbers')
 
 
 class wizard_create_crm_phonecall(models.TransientModel):


### PR DESCRIPTION
This PR is designed to avoid Travis errors such as this one:
https://travis-ci.org/OCA/sale-workflow/jobs/164489455
The sale-workflow project doesn't include connector-telephony via oca_dependencies.txt, but it includes account-invoicing which has "connector-telephony" in oca_dependencies.txt. So the Travis of sale-workflow has connector-telephony in its addons_path but it doesn't have the phonenumbers lib... which triggers the problem.
