### PR TITLE
[FIX] Fix point_of_sale partner error

### DIFF
--- a/base_phone/fields.py
+++ b/base_phone/fields.py
@@ -125,6 +125,12 @@ def write(self, vals):
     fields_to_convert = get_phone_fields(self, vals)
     if fields_to_convert:
         for record in self:
+            # When updating a partner in the frontend of the POS
+            # Odoo generate a write() with the ID of the country as unicode !!!
+            # example : vals = {u'country_id': u'9'}
+            # So we have to convert it to an integer before browsing
+            if vals[u'country_id']:
+                vals[u'country_id'] = int(vals[u'country_id'])
             loc_vals = convert_all_phone_fields(
                 record, vals, fields_to_convert)
             original_write(record, loc_vals)
@@ -138,6 +144,12 @@ def write(self, vals):
 def create(self, vals):
     fields_to_convert = get_phone_fields(self, vals)
     if fields_to_convert:
+        # When creating a partner in the frontend of the POS
+        # Odoo generate a create() with the ID of the country as unicode !!!
+        # example : vals = {u'country_id': u'9'}
+        # So we have to convert it to an integer before browsing
+        if vals[u'country_id']:
+            vals[u'country_id'] = int(vals[u'country_id'])
         vals = convert_all_phone_fields(self, vals, fields_to_convert)
     return original_create(self, vals)
 

--- a/base_phone/fields.py
+++ b/base_phone/fields.py
@@ -129,7 +129,11 @@ def write(self, vals):
             # Odoo generate a write() with the ID of the country as unicode !!!
             # example : vals = {u'country_id': u'9'}
             # So we have to convert it to an integer before browsing
-            if vals['country_id']:
+            try:
+                vals['country_id']
+            except:
+                continue
+            else:
                 vals['country_id'] = int(vals['country_id'])
             loc_vals = convert_all_phone_fields(
                 record, vals, fields_to_convert)
@@ -148,7 +152,11 @@ def create(self, vals):
         # Odoo generate a create() with the ID of the country as unicode !!!
         # example : vals = {u'country_id': u'9'}
         # So we have to convert it to an integer before browsing
-        if vals['country_id']:
+        try:
+            vals['country_id']
+        except:
+            continue
+        else:
             vals['country_id'] = int(vals['country_id'])
         vals = convert_all_phone_fields(self, vals, fields_to_convert)
     return original_create(self, vals)

--- a/base_phone/fields.py
+++ b/base_phone/fields.py
@@ -132,7 +132,7 @@ def write(self, vals):
             try:
                 vals['country_id']
             except:
-                continue
+                pass
             else:
                 vals['country_id'] = int(vals['country_id'])
             loc_vals = convert_all_phone_fields(
@@ -155,7 +155,7 @@ def create(self, vals):
         try:
             vals['country_id']
         except:
-            continue
+            pass
         else:
             vals['country_id'] = int(vals['country_id'])
         vals = convert_all_phone_fields(self, vals, fields_to_convert)

--- a/base_phone/fields.py
+++ b/base_phone/fields.py
@@ -130,11 +130,9 @@ def write(self, vals):
             # example : vals = {u'country_id': u'9'}
             # So we have to convert it to an integer before browsing
             try:
-                vals['country_id']
+                vals['country_id'] = int(vals['country_id'])
             except:
                 pass
-            else:
-                vals['country_id'] = int(vals['country_id'])
             loc_vals = convert_all_phone_fields(
                 record, vals, fields_to_convert)
             original_write(record, loc_vals)

--- a/base_phone/fields.py
+++ b/base_phone/fields.py
@@ -129,8 +129,8 @@ def write(self, vals):
             # Odoo generate a write() with the ID of the country as unicode !!!
             # example : vals = {u'country_id': u'9'}
             # So we have to convert it to an integer before browsing
-            if vals[u'country_id']:
-                vals[u'country_id'] = int(vals[u'country_id'])
+            if vals['country_id']:
+                vals['country_id'] = int(vals['country_id'])
             loc_vals = convert_all_phone_fields(
                 record, vals, fields_to_convert)
             original_write(record, loc_vals)
@@ -148,8 +148,8 @@ def create(self, vals):
         # Odoo generate a create() with the ID of the country as unicode !!!
         # example : vals = {u'country_id': u'9'}
         # So we have to convert it to an integer before browsing
-        if vals[u'country_id']:
-            vals[u'country_id'] = int(vals[u'country_id'])
+        if vals['country_id']:
+            vals['country_id'] = int(vals['country_id'])
         vals = convert_all_phone_fields(self, vals, fields_to_convert)
     return original_create(self, vals)
 


### PR DESCRIPTION
When updating a partner in the frontend of the POS Odoo generate a write() with the ID of the country as unicode !!!
example : vals = {u'country_id': u'9'}
So we have to convert it to an integer before browsing
