### PR TITLE
[FIX] Fix point_of_sale partner error

### DIFF
--- a/base_phone/fields.py
+++ b/base_phone/fields.py
@@ -7,10 +7,14 @@
 
 from openerp import api, fields, models
 from operator import attrgetter
-import phonenumbers
 import logging
 
 _logger = logging.getLogger(__name__)
+
+try:
+    import phonenumbers
+except ImportError:
+    _logger.debug('Cannot `import phonenumbers`.')
 
 
 class Phone(fields.Char):

--- a/base_phone/fields.py
+++ b/base_phone/fields.py
@@ -125,11 +125,9 @@ def write(self, vals):
         # example : vals = {u'country_id': u'9'}
         # So we have to convert it to an integer before browsing
         try:
-            vals['country_id']
+            vals['country_id'] = int(vals['country_id'])
         except:
             pass
-        else:
-            vals['country_id'] = int(vals['country_id'])
         for record in self:
             loc_vals = convert_all_phone_fields(
                 record, vals, fields_to_convert)
@@ -149,11 +147,9 @@ def create(self, vals):
         # example : vals = {u'country_id': u'9'}
         # So we have to convert it to an integer before browsing
         try:
-            vals['country_id']
+            vals['country_id'] = int(vals['country_id'])
         except:
             pass
-        else:
-            vals['country_id'] = int(vals['country_id'])
         vals = convert_all_phone_fields(self, vals, fields_to_convert)
     return original_create(self, vals)
 

--- a/base_phone/fields.py
+++ b/base_phone/fields.py
@@ -121,8 +121,8 @@ def write(self, vals):
             # Odoo generate a write() with the ID of the country as unicode !!!
             # example : vals = {u'country_id': u'9'}
             # So we have to convert it to an integer before browsing
-            if vals[u'country_id']:
-                vals[u'country_id'] = int(vals[u'country_id'])
+            if vals['country_id']:
+                vals['country_id'] = int(vals['country_id'])
             loc_vals = convert_all_phone_fields(
                 record, vals, fields_to_convert)
             original_write(record, loc_vals)
@@ -140,8 +140,8 @@ def create(self, vals):
         # Odoo generate a create() with the ID of the country as unicode !!!
         # example : vals = {u'country_id': u'9'}
         # So we have to convert it to an integer before browsing
-        if vals[u'country_id']:
-            vals[u'country_id'] = int(vals[u'country_id'])
+        if vals['country_id']:
+            vals['country_id'] = int(vals['country_id'])
         vals = convert_all_phone_fields(self, vals, fields_to_convert)
     return original_create(self, vals)
 

--- a/base_phone/fields.py
+++ b/base_phone/fields.py
@@ -118,14 +118,14 @@ original_create = models.Model.create
 
 @api.multi
 def write(self, vals):
-    # When updating a partner in the frontend of the POS
-    # Odoo generate a write() with the ID of the country as unicode !!!
-    # example : vals = {u'country_id': u'9'}
-    # So we have to convert it to an integer before browsing
-    if vals['country_id']:
-        vals['country_id'] = int(vals['country_id'])
     fields_to_convert = get_phone_fields(self, vals)
     if fields_to_convert:
+        # When updating a partner in the frontend of the POS
+        # Odoo generate a write() with the ID of the country as unicode !!!
+        # example : vals = {u'country_id': u'9'}
+        # So we have to convert it to an integer before browsing
+        if vals['country_id']:
+            vals['country_id'] = int(vals['country_id'])
         for record in self:
             loc_vals = convert_all_phone_fields(
                 record, vals, fields_to_convert)
@@ -138,14 +138,14 @@ def write(self, vals):
 @api.model
 @api.returns('self', lambda value: value.id)
 def create(self, vals):
-    # When creating a partner in the frontend of the POS
-    # Odoo generate a create() with the ID of the country as unicode !!!
-    # example : vals = {u'country_id': u'9'}
-    # So we have to convert it to an integer before browsing
-    if vals['country_id']:
-        vals['country_id'] = int(vals['country_id'])
     fields_to_convert = get_phone_fields(self, vals)
     if fields_to_convert:
+        # When creating a partner in the frontend of the POS
+        # Odoo generate a create() with the ID of the country as unicode !!!
+        # example : vals = {u'country_id': u'9'}
+        # So we have to convert it to an integer before browsing
+        if vals['country_id']:
+            vals['country_id'] = int(vals['country_id'])
         vals = convert_all_phone_fields(self, vals, fields_to_convert)
     return original_create(self, vals)
 

--- a/base_phone/fields.py
+++ b/base_phone/fields.py
@@ -124,7 +124,11 @@ def write(self, vals):
         # Odoo generate a write() with the ID of the country as unicode !!!
         # example : vals = {u'country_id': u'9'}
         # So we have to convert it to an integer before browsing
-        if vals['country_id']:
+        try:
+            vals['country_id']
+        except:
+            continue
+        else:
             vals['country_id'] = int(vals['country_id'])
         for record in self:
             loc_vals = convert_all_phone_fields(
@@ -144,7 +148,11 @@ def create(self, vals):
         # Odoo generate a create() with the ID of the country as unicode !!!
         # example : vals = {u'country_id': u'9'}
         # So we have to convert it to an integer before browsing
-        if vals['country_id']:
+        try:
+            vals['country_id']
+        except:
+            continue
+        else:
             vals['country_id'] = int(vals['country_id'])
         vals = convert_all_phone_fields(self, vals, fields_to_convert)
     return original_create(self, vals)

--- a/base_phone/fields.py
+++ b/base_phone/fields.py
@@ -118,15 +118,15 @@ original_create = models.Model.create
 
 @api.multi
 def write(self, vals):
+    # When updating a partner in the frontend of the POS
+    # Odoo generate a write() with the ID of the country as unicode !!!
+    # example : vals = {u'country_id': u'9'}
+    # So we have to convert it to an integer before browsing
+    if vals['country_id']:
+        vals['country_id'] = int(vals['country_id'])
     fields_to_convert = get_phone_fields(self, vals)
     if fields_to_convert:
         for record in self:
-            # When updating a partner in the frontend of the POS
-            # Odoo generate a write() with the ID of the country as unicode !!!
-            # example : vals = {u'country_id': u'9'}
-            # So we have to convert it to an integer before browsing
-            if vals['country_id']:
-                vals['country_id'] = int(vals['country_id'])
             loc_vals = convert_all_phone_fields(
                 record, vals, fields_to_convert)
             original_write(record, loc_vals)
@@ -138,14 +138,14 @@ def write(self, vals):
 @api.model
 @api.returns('self', lambda value: value.id)
 def create(self, vals):
+    # When creating a partner in the frontend of the POS
+    # Odoo generate a create() with the ID of the country as unicode !!!
+    # example : vals = {u'country_id': u'9'}
+    # So we have to convert it to an integer before browsing
+    if vals['country_id']:
+        vals['country_id'] = int(vals['country_id'])
     fields_to_convert = get_phone_fields(self, vals)
     if fields_to_convert:
-        # When creating a partner in the frontend of the POS
-        # Odoo generate a create() with the ID of the country as unicode !!!
-        # example : vals = {u'country_id': u'9'}
-        # So we have to convert it to an integer before browsing
-        if vals['country_id']:
-            vals['country_id'] = int(vals['country_id'])
         vals = convert_all_phone_fields(self, vals, fields_to_convert)
     return original_create(self, vals)
 

--- a/base_phone/fields.py
+++ b/base_phone/fields.py
@@ -117,6 +117,12 @@ def write(self, vals):
     fields_to_convert = get_phone_fields(self, vals)
     if fields_to_convert:
         for record in self:
+            # When updating a partner in the frontend of the POS
+            # Odoo generate a write() with the ID of the country as unicode !!!
+            # example : vals = {u'country_id': u'9'}
+            # So we have to convert it to an integer before browsing
+            if vals[u'country_id']:
+                vals[u'country_id'] = int(vals[u'country_id'])
             loc_vals = convert_all_phone_fields(
                 record, vals, fields_to_convert)
             original_write(record, loc_vals)
@@ -130,6 +136,12 @@ def write(self, vals):
 def create(self, vals):
     fields_to_convert = get_phone_fields(self, vals)
     if fields_to_convert:
+        # When creating a partner in the frontend of the POS
+        # Odoo generate a create() with the ID of the country as unicode !!!
+        # example : vals = {u'country_id': u'9'}
+        # So we have to convert it to an integer before browsing
+        if vals[u'country_id']:
+            vals[u'country_id'] = int(vals[u'country_id'])
         vals = convert_all_phone_fields(self, vals, fields_to_convert)
     return original_create(self, vals)
 

--- a/base_phone/fields.py
+++ b/base_phone/fields.py
@@ -127,7 +127,7 @@ def write(self, vals):
         try:
             vals['country_id']
         except:
-            continue
+            pass
         else:
             vals['country_id'] = int(vals['country_id'])
         for record in self:
@@ -151,7 +151,7 @@ def create(self, vals):
         try:
             vals['country_id']
         except:
-            continue
+            pass
         else:
             vals['country_id'] = int(vals['country_id'])
         vals = convert_all_phone_fields(self, vals, fields_to_convert)

--- a/base_phone/models/phone_common.py
+++ b/base_phone/models/phone_common.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import models, api
-from .fields import Phone
+from .. import fields as Phone
 import logging
 
 _logger = logging.getLogger(__name__)

--- a/base_phone/models/phone_common.py
+++ b/base_phone/models/phone_common.py
@@ -3,12 +3,16 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import models, api
-from openerp.addons.base_phone.fields import Phone
+from .fields import Phone
 import logging
-# Lib for phone number reformating -> pip install phonenumbers
-import phonenumbers
 
 _logger = logging.getLogger(__name__)
+
+# Lib for phone number reformating -> pip install phonenumbers
+try:
+    import phonenumbers
+except ImportError:
+    _logger.debug('Cannot `import phonenumbers`.')
 
 
 class PhoneCommon(models.AbstractModel):

--- a/base_phone/models/phone_common.py
+++ b/base_phone/models/phone_common.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import models, api
-from .. import fields as Phone
+from .. import fields as phone_fields
 import logging
 
 _logger = logging.getLogger(__name__)
@@ -106,7 +106,7 @@ class PhoneCommon(models.AbstractModel):
         for (obj, prio) in phoneobj_sorted:
             entry = {'object': obj, 'fields': []}
             for field in obj._fields:
-                if isinstance(obj._fields[field], Phone):
+                if isinstance(obj._fields[field], phone_fields.Phone):
                     entry['fields'].append(field)
             res.append(entry)
         # [{'fields': ['fax', 'phone', 'mobile'], 'object': res.partner()},

--- a/base_phone/models/res_partner.py
+++ b/base_phone/models/res_partner.py
@@ -4,7 +4,7 @@
 
 
 from openerp import models, api
-from . import fields
+from .. import fields
 
 
 class ResPartner(models.Model):

--- a/base_phone/models/res_partner.py
+++ b/base_phone/models/res_partner.py
@@ -4,7 +4,7 @@
 
 
 from openerp import models, api
-from openerp.addons.base_phone import fields
+from . import fields
 
 
 class ResPartner(models.Model):

--- a/base_phone/wizard/number_not_found.py
+++ b/base_phone/wizard/number_not_found.py
@@ -5,9 +5,13 @@
 from openerp import models, fields, api, _
 from openerp.exceptions import UserError
 import logging
-import phonenumbers
 
 _logger = logging.getLogger(__name__)
+
+try:
+    import phonenumbers
+except ImportError:
+    _logger.debug('Cannot `import phonenumbers`.')
 
 
 class NumberNotFound(models.TransientModel):

--- a/crm_phone/__openerp__.py
+++ b/crm_phone/__openerp__.py
@@ -24,6 +24,7 @@ for any help or question about this module.
     'author': "Akretion,Odoo Community Association (OCA)",
     'website': 'http://www.akretion.com/',
     'depends': ['base_phone', 'crm'],
+    'external_dependencies': {'python': ['phonenumbers']},
     'conflicts': ['crm_voip'],
     'data': [
         'security/phonecall_security.xml',

--- a/crm_phone/wizard/create_crm_phonecall.py
+++ b/crm_phone/wizard/create_crm_phonecall.py
@@ -3,7 +3,14 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import models, api, _
-import phonenumbers
+import logging
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import phonenumbers
+except ImportError:
+    _logger.debug('Cannot `import phonenumbers`.')
 
 
 class WizardCreateCrmPhonecall(models.TransientModel):


### PR DESCRIPTION
When updating a partner in the frontend of the POS Odoo generate a write() with the ID of the country as unicode !!!
example : vals = {u'country_id': u'9'}
So we have to convert it to an integer before browsing
