### PR TITLE
[8.0 ]Reproduce error message with contact us form in webiste_crm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ install:
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
   - pip install phonenumbers py-Asterisk SOAPpy
-  - hg clone http://bitbucket.org/anybox/web_action_request -b ${VERSION} ${HOME}/web_action_request
-  - hg clone http://bitbucket.org/anybox/bus_enhanced ${HOME}/bus_enhanced
+  - hg clone http://bitbucket.org/anybox/web_action_request -b ${VERSION} ${HOME}/dependencies/web_action_request
+  - hg clone http://bitbucket.org/anybox/bus_enhanced ${HOME}/dependencies/bus_enhanced
 
 script:
   - travis_run_tests

--- a/base_phone/base_phone.py
+++ b/base_phone/base_phone.py
@@ -53,7 +53,7 @@ class PhoneCommon(models.AbstractModel):
             user = self.pool['res.users'].browse(cr, uid, uid, context=context)
             # country_id on res.company is a fields.function that looks at
             # company_id.partner_id.addres(default).country_id
-            if isinstance(vals[self._country_field], (str, unicode)):
+            if self._country_field in vals and isinstance(vals[self._country_field], (str, unicode)):
                 vals[self._country_field] = int(vals[self._country_field])
             countrycode = None
             if self._country_field:

--- a/base_phone/base_phone.py
+++ b/base_phone/base_phone.py
@@ -53,6 +53,8 @@ class PhoneCommon(models.AbstractModel):
             user = self.pool['res.users'].browse(cr, uid, uid, context=context)
             # country_id on res.company is a fields.function that looks at
             # company_id.partner_id.addres(default).country_id
+            if isinstance(vals[self._country_field], (str, unicode)):
+                vals[self._country_field] = int(vals[self._country_field])
             countrycode = None
             if self._country_field:
                 if vals.get(self._country_field):

--- a/base_phone/test/phonenum.yml
+++ b/base_phone/test/phonenum.yml
@@ -51,7 +51,7 @@
 -
   Check country_id come from contact us form from website_crm module
 -
-  !python {model: phone.common}: |
+  !python {model: res.partner}: |
     vals = self._generic_reformat_phonenumbers(cr, uid, [], {
         'country_id': u'74', 'phone': u'0155667788'
     }, context=context)

--- a/base_phone/test/phonenum.yml
+++ b/base_phone/test/phonenum.yml
@@ -48,3 +48,11 @@
     assert name == 'Pierre Paillet', 'Wrong result for get_name_from_phone_number'
     name2 = self.get_name_from_phone_number(cr, uid, '0041216191010')
     assert name2 == u'Joël Grand-Guillaume (Camptocamp)', 'Wrong result for get_name_from_phone_number (partner2)'
+-
+  Check country_id come from contact us form from website_crm module
+-
+  !python {model: phone.common}: |
+    vals = self._generic_reformat_phonenumbers(cr, uid, [], {
+        'country_id': u'74', 'phone': u'0155667788'
+    }, context=context)
+    assert vals['phone'] == '+33155667788'


### PR DESCRIPTION
When choose a country on the contact us form, when we validate we have this traceback

AccessError: ('AccessError', u"Database fetch misses ids (u'74') and has extra ids (74), may be caused by a type incoherence in a previous request")

The problem is the "id" pass to the browse function is a string (not an integer)

First i have to create a test for reproduce the problem
