### PR TITLE
[FIX] base.phone : add default company on sms model

### DIFF
--- a/base_sms_client/models/sms_gateway.py
+++ b/base_sms_client/models/sms_gateway.py
@@ -62,7 +62,8 @@ class SmsAbstract(models.AbstractModel):
 
     char_limit = fields.Integer(string='Character Limit', default=160)
     default_gateway = fields.Boolean()
-    company_id = fields.Many2one(comodel_name='res.company')
+    company_id = fields.Many2one(comodel_name='res.company', 
+         default=lambda self: self.env.user.company_id)
 
 
 class SmsGateway(models.Model):


### PR DESCRIPTION
There are some rules, but if the company field is not set, nobody can see SMS : https://github.com/OCA/connector-telephony/blob/10.0/base_sms_client/security/ir.rule.csv