### PR TITLE
11.0 Onchange Methods in ResPartner to format phone, and mobile numbers

### DIFF
--- a/base_phone/models/res_partner.py
+++ b/base_phone/models/res_partner.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
-from odoo import models
+from odoo import models, api
 
 
 class ResPartner(models.Model):
@@ -28,3 +28,13 @@ class ResPartner(models.Model):
             return res
         else:
             return super(ResPartner, self).name_get()
+
+    @api.onchange('phone', 'country_id', 'company_id')
+    def _onchange_phone_validation(self):
+        if self.phone:
+            self.phone = self.phone_format(self.phone)
+
+    @api.onchange('mobile', 'country_id', 'company_id')
+    def _onchange_mobile_validation(self):
+        if self.mobile:
+            self.mobile = self.phone_format(self.mobile)


### PR DESCRIPTION
Good Morning,
I'm Oscar from SDi Soluciones (https://sdi.es).

I think it is necessary to include these onchange methods, because otherwise, and from what I have verified, the change to the international format is not made, adding the country prefix and extensions.

I have not found another way to include the extensions with the Odoo base modules.

Reviewing the code in version 12.0, I have seen that the onchange were included.

A greeting.