### PR TITLE
[FIX][12.0] Open caller button bug

### DIFF
--- a/asterisk_click2dial/static/src/js/asterisk_click2dial.js
+++ b/asterisk_click2dial/static/src/js/asterisk_click2dial.js
@@ -67,7 +67,7 @@ var OpenCallerMenu = Widget.extend({
         else if (typeof r == 'object' && r.length == 3) {
             self.do_notify(
                 _.str.sprintf(_t("On the phone with '%s'"), r[2]),
-                _.str.sprintf(_t("Moving to form view of '%s' (%s ID %d)"), r[2], r[0], r[1]),
+                _.str.sprintf(_t("Moving to form view of %s (%s ID %d)"), r[2], r[0], r[1]),
                 false);
             var action = {
                 type: 'ir.actions.act_window',

--- a/crm_phone/view/crm_lead.xml
+++ b/crm_phone/view/crm_lead.xml
@@ -36,7 +36,7 @@
             <button class="oe_inline oe_stat_button" type="action"
                 name="%(crm_phone.crm_phonecall_action)d"
                 icon="fa-phone"
-                context="{'search_default_opportunity_id': active_id}">
+                context="{'search_default_opportunity_id': id}">
                 <field string="Calls" name="phonecall_count" widget="statinfo"/>
              </button>
         </div>


### PR DESCRIPTION
This is a strange bug that appears when single quotes are used inside a double quote translated string. The error message:
`Uncaught Error: [_.sprintf] expecting number but found string`
is triggered as if it modified the way formats behave. Using an escaped double quote is not a solution neither because it appears as a double quote with a preceding backslash in the resulting string. Here are a few options to solve this issue:
- Remove the single quotes (chosen solution)
- Add a white space after the first and before the second single quotes
- Add a second single quote either before, after or only one of the two possibilities
- Use an escaped double quote (_\"_) but the backslash appears in the resulting string
It may be an issue that also appears on the official _OCA_ repository as well but it seems strange that nobody figured that this problem exists. Also, this PR avoids the exception that is thrown, but it does not propose a solution to still be able to use a quote inside a formatted string.

It fixes also an issue where you don't get the correct phonecalls when you go from a partner into his opportunities and then in the phonecalls, because the active_id is then associated to a partner and not an opportunity.