### PR TITLE
[14.0][ADD] sms_no_alter_body module

### DIFF
--- a/setup/sms_no_alter_body/odoo/addons/sms_no_alter_body
+++ b/setup/sms_no_alter_body/odoo/addons/sms_no_alter_body
@@ -1,0 +1,1 @@
+../../../../sms_no_alter_body

--- a/setup/sms_no_alter_body/setup.py
+++ b/setup/sms_no_alter_body/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/sms_no_alter_body/__init__.py
+++ b/sms_no_alter_body/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sms_no_alter_body/__manifest__.py
+++ b/sms_no_alter_body/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "SMS no atler body",
+    "summary": "Avoid sms formatting between html and text",
+    "version": "14.0.1.0.0",
+    "category": "Phone",
+    "website": "https://github.com/OCA/connector-telephony",
+    "author": "Akretion, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "sms",
+    ],
+}

--- a/sms_no_alter_body/models/__init__.py
+++ b/sms_no_alter_body/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sms_sms
+from . import mail_thread

--- a/sms_no_alter_body/models/mail_thread.py
+++ b/sms_no_alter_body/models/mail_thread.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2021 Akretion (<http://www.akretion.com>).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    @api.returns("mail.message", lambda value: value.id)
+    def _message_sms(self, body, **kwargs):
+        self = self.with_context(force_sms_body=body)
+        return super()._message_sms(body, **kwargs)

--- a/sms_no_alter_body/models/sms_sms.py
+++ b/sms_no_alter_body/models/sms_sms.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2021 Akretion (<http://www.akretion.com>).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class SmsSms(models.Model):
+    _inherit = "sms.sms"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        if self._context.get("force_sms_body"):
+            for vals in vals_list:
+                vals["body"] = self._context["force_sms_body"]
+        return super().create(vals_list)

--- a/sms_no_alter_body/readme/CONTRIBUTORS.rst
+++ b/sms_no_alter_body/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+Kévin Roche <kevin.roche@akretion.com>

--- a/sms_no_alter_body/readme/DESCRIPTION.rst
+++ b/sms_no_alter_body/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+Skipping the formatting of sms between html and text by using the original "body" of messages.
+For exemple, this module cancels the duplicate URL at the sms's end.

--- a/sms_no_alter_body/tests/__init__.py
+++ b/sms_no_alter_body/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sms_no_alter_body

--- a/sms_no_alter_body/tests/test_sms_no_alter_body.py
+++ b/sms_no_alter_body/tests/test_sms_no_alter_body.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2021 Akretion (<http://www.akretion.com>).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestSmsNoAlterBody(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.partner = self.env["res.partner"].create(
+            {"name": "FOO", "mobile": "+3360707070707"}
+        )
+
+    def test_force_sms_body(self):
+        message = self.partner._message_sms("Welcome to https://akretion.com/fr")
+        message_sms_body = (
+            self.env["sms.sms"].search([("mail_message_id", "=", message.id)]).body
+        )
+        self.assertEqual(message_sms_body, "Welcome to https://akretion.com/fr")


### PR DESCRIPTION
When sending sms with the "_message_sms" method, some formatting are occuring between html and text. Consequently, if an URL is present in the initial sms's body, it will appeared twice in the final sms. This module avoids this kind of behavior. 