### PR TITLE
[17.0][IMP] voip_oca: Update z-index for proper layering

### DIFF
--- a/voip_oca/static/src/components/softphone/softphone.scss
+++ b/voip_oca/static/src/components/softphone/softphone.scss
@@ -2,7 +2,7 @@
     width: 300px;
     height: auto;
     max-height: 70%;
-    z-index: 99;
+    z-index: 1001;
 
     .o_voip_softphone_header {
         background-color: $o-community-color !important;


### PR DESCRIPTION
When the `web_responsive` module is installed, the VoIP component is not displayed in the main menu because `web_responsive` has a [higher z-index](https://github.com/OCA/web/blob/32184c6f6b6c34a2660e4adbe8271f2021f22bdf/web_responsive/static/src/components/apps_menu/apps_menu.scss#L35 ).

Before

https://github.com/user-attachments/assets/cbbedd60-b6e8-4be2-869a-e84047439386



After this commit, the VoIP component will always be displayed.


https://github.com/user-attachments/assets/f1ba597d-5e7e-4edc-8da8-e69eda84db7b

@Tecnativa @pedrobaeza @etobella could you please review this?
