### PR TITLE
[18.0][FIX] voip_oca: filter activities to avoid accessing records the user cannot read

### DIFF
--- a/voip_oca/models/mail_activity.py
+++ b/voip_oca/models/mail_activity.py
@@ -40,5 +40,12 @@ class VoipOcaActivity(models.Model):
                 [[(field, "ilike", _search)] for field in search_fields]
             )
             domain = expression.AND([domain, search_domain])
-        activities = self.search(domain, offset=offset, limit=limit)
-        return activities.activity_format()
+        all_activities = self.search(domain, offset=offset, limit=limit)
+        # Filter activities to avoid accessing records that the user cannot read
+        # due to multi-company restrictions or other access rules in the res_model.
+        allowed_activity_ids = []
+        for activity in all_activities:
+            res_record = self.env[activity.res_model].browse(activity.res_id)
+            if res_record._filtered_access("read"):
+                allowed_activity_ids.append(activity.id)
+        return self.browse(allowed_activity_ids).activity_format()


### PR DESCRIPTION
In a multi-company environment, when Odoo searches for activities to display in the systray, an error is raised:
"Uh-oh! Looks like you have stumbled upon some top-secret records."

This occurs because some activities point to records that the current user does not have access to, due to multi-company restrictions or other access rules defined in the `res_model`.

Steps to reproduce:

- In a fresh database with demo data, install the `voip_oca` and `account` modules.
- Create a new company.
- Switch to the new company.


Forward-port of https://github.com/OCA/connector-telephony/pull/346

@Tecnativa @pedrobaeza @etobella could you please review this?