### PR TITLE
[18.0][IMP] voip_oca: Update z-index for proper layering

### DIFF
--- a/voip_oca/static/src/components/softphone/softphone.scss
+++ b/voip_oca/static/src/components/softphone/softphone.scss
@@ -2,7 +2,7 @@
     width: 300px;
     height: auto;
     max-height: 70%;
-    z-index: 99;
+    z-index: 1001;
 
     .o_voip_softphone_header {
         background-color: $o-community-color !important;


### PR DESCRIPTION
When the web_responsive module is installed, the VoIP component is not displayed in the main menu because web_responsive has a higher z-index.

https://github.com/OCA/web/blob/32184c6f6b6c34a2660e4adbe8271f2021f22bdf/web_responsive/static/src/components/apps_menu/apps_menu.scss#L35 After this commit, the VoIP component will always be displayed.

FWP of https://github.com/OCA/connector-telephony/pull/347

@Tecnativa @pedrobaeza @etobella @eduezerouali-tecnativa could you please review this?