### PR TITLE
[19.0][IMP] voip_oca: Update z-index for proper layering

### DIFF
--- a/voip_oca/static/src/components/softphone/softphone.scss
+++ b/voip_oca/static/src/components/softphone/softphone.scss
@@ -2,7 +2,7 @@
     width: 300px;
     height: auto;
     max-height: 70%;
-    z-index: 99;
+    z-index: 1025;
 
     .o_voip_softphone_header {
         background-color: $o-community-color !important;


### PR DESCRIPTION
When the web_responsive module is installed, the VoIP component is not displayed in the main menu because web_responsive has a higher z-index.

https://github.com/OCA/web/blob/e1a6026b30c3b59aa290b5b39e09af59059a7e3c/web_responsive/static/src/components/apps_menu/apps_menu.scss#L96 After this commit, the VoIP component will always be displayed.

FWP of https://github.com/OCA/connector-telephony/pull/369

@Tecnativa @pedrobaeza @etobella @eduezerouali-tecnativa could you please review this?