### PR TITLE
[16.0][IMP] sms_ovh_http: migrate to OVH new API (python-ovh)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # generated from manifests external_dependencies
+ovh
 phonenumbers
 requests
 twilio

--- a/sms_ovh_http/README.rst
+++ b/sms_ovh_http/README.rst
@@ -28,8 +28,8 @@ Sms OVH HTTP
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-Implementation of **OVH http2sms API** for sending sms.
-This module depend of odoo native **sms** module it only implement ovh as provider instead of odoo SA.
+Implementation of **OVH API** for sending SMS using the official python-ovh SDK.
+This module depends on Odoo's native **sms** module and implements OVH as a provider instead of Odoo SA.
 
 **Table of contents**
 
@@ -41,25 +41,20 @@ Configuration
 
 To configure this module, you need to:
 
-* Go to settings > technical > IAP Account
+* Go to Settings > Technical > IAP Account
 * Create a new account with **SMS OVH HTTP** as provider
-* Fill your account information as follows:
-    * SMS Account
+* Fill in your OVH API credentials:
 
-      .. figure:: https://raw.githubusercontent.com/OCA/connector-telephony/16.0/sms_ovh_http/static/img/img.png
-         :width: 800 px
+  * **Application Key**: your OVH application key
+  * **Application Secret**: your OVH application secret
+  * **Consumer Key**: your OVH consumer key
+  * **Service Name**: your OVH SMS service name (e.g. ``sms-ab1234-1``)
+  * **Sender Name**: the sender name displayed on the SMS
 
-    * API User ID / API User Password
+* You can now send an SMS!
 
-      .. figure:: https://raw.githubusercontent.com/OCA/connector-telephony/16.0/sms_ovh_http/static/img/img_1.png
-         :width: 800 px
-
-    * Sender name
-
-      .. figure:: https://raw.githubusercontent.com/OCA/connector-telephony/16.0/sms_ovh_http/static/img/img_2.png
-         :width: 800 px
-
-    * You can now send an sms!
+To generate your OVH API credentials, visit https://api.ovh.com/createToken/ and
+request ``POST /sms/{serviceName}/jobs`` permission.
 
 Bug Tracker
 ===========

--- a/sms_ovh_http/__manifest__.py
+++ b/sms_ovh_http/__manifest__.py
@@ -4,8 +4,8 @@
 
 {
     "name": "Sms OVH HTTP",
-    "summary": "Send sms using ovh http API",
-    "version": "16.0.1.0.0",
+    "summary": "Send sms using ovh http API or new OVH API (python-ovh)",
+    "version": "16.0.2.0.0",
     "category": "SMS",
     "website": "https://github.com/OCA/connector-telephony",
     "author": "Akretion, Odoo Community Association (OCA)",
@@ -13,7 +13,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "external_dependencies": {"python": [], "bin": []},
+    "external_dependencies": {"python": ["ovh"], "bin": []},
     "depends": ["base_phone", "sms", "iap_alternative_provider"],
     "data": [
         "views/iap_account_view.xml",

--- a/sms_ovh_http/models/iap_account.py
+++ b/sms_ovh_http/models/iap_account.py
@@ -12,10 +12,11 @@ class IapAccount(models.Model):
         selection_add=[("sms_ovh_http", "SMS OVH http")],
         ondelete={"sms_ovh_http": "cascade"},
     )
-    sms_ovh_http_account = fields.Char(string="SMS Account")
-    sms_ovh_http_login = fields.Char(string="API User ID")
-    sms_ovh_http_password = fields.Char(string="API User Password")
     sms_ovh_http_from = fields.Char(string="Sender Name")
+    sms_ovh_http_app_key = fields.Char(string="Application Key")
+    sms_ovh_http_app_secret = fields.Char(string="Application Secret")
+    sms_ovh_http_consumer_key = fields.Char(string="Consumer Key")
+    sms_ovh_http_service_name = fields.Char(string="Service Name")
 
     def _get_service_from_provider(self):
         if self.provider == "sms_ovh_http":
@@ -26,10 +27,11 @@ class IapAccount(models.Model):
         res = super()._server_env_fields
         res.update(
             {
-                "sms_ovh_http_account": {},
-                "sms_ovh_http_login": {},
-                "sms_ovh_http_password": {},
                 "sms_ovh_http_from": {},
+                "sms_ovh_http_app_key": {},
+                "sms_ovh_http_app_secret": {},
+                "sms_ovh_http_consumer_key": {},
+                "sms_ovh_http_service_name": {},
             }
         )
         return res

--- a/sms_ovh_http/models/sms_api.py
+++ b/sms_ovh_http/models/sms_api.py
@@ -3,49 +3,42 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 
-import requests
+import ovh
 
 from odoo import _, api, models
 from odoo.exceptions import UserError
 
-OVH_HTTP_ENDPOINT = "https://www.ovh.com/cgi-bin/sms/http2sms.cgi"
+OVH_API_ENDPOINT = "ovh-eu"
 
 
 class SmsApi(models.AbstractModel):
     _inherit = "sms.api"
 
-    HTTP_TIMEOUT = 10
-
-    def _prepare_ovh_http_params(self, account, number, message):
-        return {
-            "smsAccount": account.sms_ovh_http_account,
-            "login": account.sms_ovh_http_login,
-            "password": account.sms_ovh_http_password,
-            "from": account.sms_ovh_http_from,
-            "to": number,
-            "message": message,
-            "noStop": 1,
-        }
-
     def _get_sms_account(self):
         return self.env["iap.account"].get("sms").exists()
 
-    def _send_sms_with_ovh_http(self, number, message, sms_id):
-        # Try to return same error code like odoo
-        # list is here: self.IAP_TO_SMS_STATE
+    def _send_sms_with_ovh_api(self, number, message, sms_id):
         if not number:
             return "wrong_number_format"
         account = self._get_sms_account()
-        r = requests.get(
-            OVH_HTTP_ENDPOINT,
-            params=self._prepare_ovh_http_params(account, number, message),
-            timeout=self.HTTP_TIMEOUT,
+        client = ovh.Client(
+            endpoint=OVH_API_ENDPOINT,
+            application_key=account.sms_ovh_http_app_key,
+            application_secret=account.sms_ovh_http_app_secret,
+            consumer_key=account.sms_ovh_http_consumer_key,
         )
-        response = r.text
-        if response[0:2] != "OK":
-            self.env["sms.sms"].browse(sms_id).error_detail = response
+        try:
+            client.post(
+                "/sms/%s/jobs" % account.sms_ovh_http_service_name,
+                message=message,
+                sender=account.sms_ovh_http_from,
+                receivers=[number],
+                noStopClause=True,
+            )
+            return "success"
+        except ovh.exceptions.APIError as e:
+            self.env["sms.sms"].browse(sms_id).error_detail = str(e)
             return "server_error"
-        return "success"
 
     def _is_sent_with_ovh(self):
         return self._get_sms_account().provider == "sms_ovh_http"
@@ -53,12 +46,6 @@ class SmsApi(models.AbstractModel):
     @api.model
     def _send_sms(self, numbers, message):
         if self._is_sent_with_ovh():
-            # This method seem to be deprecated (no odoo code use it)
-            # as OVH do not support it we do not support it
-            # Note: if you want to implement it becarefull just looping
-            # on the list of number is not the right way to do it.
-            # If you have an error, you will send and send again the same
-            # message
             raise NotImplementedError
         else:
             return super()._send_sms(numbers, message)
@@ -67,12 +54,11 @@ class SmsApi(models.AbstractModel):
     def _send_sms_batch(self, messages):
         if self._is_sent_with_ovh():
             if len(messages) != 1:
-                # we already have inherited the split_batch method on sms.sms
-                # so this case shouldsnot append
-                raise UserError(_("Batch sending is not support with OVH"))
-            state = self._send_sms_with_ovh_http(
-                messages[0]["number"], messages[0]["content"], messages[0]["res_id"]
+                raise UserError(_("Batch sending is not supported with OVH"))
+            msg = messages[0]
+            state = self._send_sms_with_ovh_api(
+                msg["number"], msg["content"], msg["res_id"]
             )
-            return [{"state": state, "credit": 0, "res_id": messages[0]["res_id"]}]
+            return [{"state": state, "credit": 0, "res_id": msg["res_id"]}]
         else:
             return super()._send_sms_batch(messages)

--- a/sms_ovh_http/readme/CONFIGURE.rst
+++ b/sms_ovh_http/readme/CONFIGURE.rst
@@ -1,21 +1,16 @@
 To configure this module, you need to:
 
-* Go to settings > technical > IAP Account
+* Go to Settings > Technical > IAP Account
 * Create a new account with **SMS OVH HTTP** as provider
-* Fill your account information as follows:
-    * SMS Account
+* Fill in your OVH API credentials:
 
-      .. figure:: ../static/img/img.png
-         :width: 800 px
+  * **Application Key**: your OVH application key
+  * **Application Secret**: your OVH application secret
+  * **Consumer Key**: your OVH consumer key
+  * **Service Name**: your OVH SMS service name (e.g. ``sms-ab1234-1``)
+  * **Sender Name**: the sender name displayed on the SMS
 
-    * API User ID / API User Password
+* You can now send an SMS!
 
-      .. figure:: ../static/img/img_1.png
-         :width: 800 px
-
-    * Sender name
-
-      .. figure:: ../static/img/img_2.png
-         :width: 800 px
-
-    * You can now send an sms!
+To generate your OVH API credentials, visit https://api.ovh.com/createToken/ and
+request ``POST /sms/{serviceName}/jobs`` permission.

--- a/sms_ovh_http/readme/DESCRIPTION.rst
+++ b/sms_ovh_http/readme/DESCRIPTION.rst
@@ -1,2 +1,2 @@
-Implementation of **OVH http2sms API** for sending sms.
-This module depend of odoo native **sms** module it only implement ovh as provider instead of odoo SA.
+Implementation of **OVH API** for sending SMS using the official python-ovh SDK.
+This module depends on Odoo's native **sms** module and implements OVH as a provider instead of Odoo SA.

--- a/sms_ovh_http/static/description/index.html
+++ b/sms_ovh_http/static/description/index.html
@@ -370,8 +370,8 @@ ul.auto-toc {
 !! source digest: sha256:efc084f31e66d2a27ad3e84ca1398185bd4cc087e0810f2341bea423a6224144
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/connector-telephony/tree/16.0/sms_ovh_http"><img alt="OCA/connector-telephony" src="https://img.shields.io/badge/github-OCA%2Fconnector--telephony-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/connector-telephony-16-0/connector-telephony-16-0-sms_ovh_http"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/connector-telephony&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>Implementation of <strong>OVH http2sms API</strong> for sending sms.
-This module depend of odoo native <strong>sms</strong> module it only implement ovh as provider instead of odoo SA.</p>
+<p>Implementation of <strong>OVH API</strong> for sending SMS using the official python-ovh SDK.
+This module depends on Odoo’s native <strong>sms</strong> module and implements OVH as a provider instead of Odoo SA.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -388,36 +388,21 @@ This module depend of odoo native <strong>sms</strong> module it only implement 
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
 <p>To configure this module, you need to:</p>
-<ul>
-<li><p class="first">Go to settings &gt; technical &gt; IAP Account</p>
-</li>
-<li><p class="first">Create a new account with <strong>SMS OVH HTTP</strong> as provider</p>
-</li>
-<li><dl class="first docutils">
-<dt>Fill your account information as follows:</dt>
-<dd><ul class="first last">
-<li><p class="first">SMS Account</p>
-<div class="figure">
-<img alt="https://raw.githubusercontent.com/OCA/connector-telephony/16.0/sms_ovh_http/static/img/img.png" src="https://raw.githubusercontent.com/OCA/connector-telephony/16.0/sms_ovh_http/static/img/img.png" style="width: 800px;" />
-</div>
-</li>
-<li><p class="first">API User ID / API User Password</p>
-<div class="figure">
-<img alt="https://raw.githubusercontent.com/OCA/connector-telephony/16.0/sms_ovh_http/static/img/img_1.png" src="https://raw.githubusercontent.com/OCA/connector-telephony/16.0/sms_ovh_http/static/img/img_1.png" style="width: 800px;" />
-</div>
-</li>
-<li><p class="first">Sender name</p>
-<div class="figure">
-<img alt="https://raw.githubusercontent.com/OCA/connector-telephony/16.0/sms_ovh_http/static/img/img_2.png" src="https://raw.githubusercontent.com/OCA/connector-telephony/16.0/sms_ovh_http/static/img/img_2.png" style="width: 800px;" />
-</div>
-</li>
-<li><p class="first">You can now send an sms!</p>
-</li>
+<ul class="simple">
+<li>Go to Settings &gt; Technical &gt; IAP Account</li>
+<li>Create a new account with <strong>SMS OVH HTTP</strong> as provider</li>
+<li>Fill in your OVH API credentials:<ul>
+<li><strong>Application Key</strong>: your OVH application key</li>
+<li><strong>Application Secret</strong>: your OVH application secret</li>
+<li><strong>Consumer Key</strong>: your OVH consumer key</li>
+<li><strong>Service Name</strong>: your OVH SMS service name (e.g. <tt class="docutils literal"><span class="pre">sms-ab1234-1</span></tt>)</li>
+<li><strong>Sender Name</strong>: the sender name displayed on the SMS</li>
 </ul>
-</dd>
-</dl>
 </li>
+<li>You can now send an SMS!</li>
 </ul>
+<p>To generate your OVH API credentials, visit <a class="reference external" href="https://api.ovh.com/createToken/">https://api.ovh.com/createToken/</a> and
+request <tt class="docutils literal">POST <span class="pre">/sms/{serviceName}/jobs</span></tt> permission.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>

--- a/sms_ovh_http/tests/test_send_sms.py
+++ b/sms_ovh_http/tests/test_send_sms.py
@@ -2,11 +2,11 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-import requests_mock
+from unittest.mock import patch
 
 from odoo.tests import TransactionCase
 
-from ..models.sms_api import OVH_HTTP_ENDPOINT
+from ..models.sms_api import OVH_API_ENDPOINT
 
 
 class SendSmsCase(TransactionCase):
@@ -17,9 +17,10 @@ class SendSmsCase(TransactionCase):
             {
                 "name": "OVH",
                 "provider": "sms_ovh_http",
-                "sms_ovh_http_account": "foo",
-                "sms_ovh_http_login": "bar",
-                "sms_ovh_http_password": "secret",
+                "sms_ovh_http_app_key": "app_key_test",
+                "sms_ovh_http_app_secret": "app_secret_test",
+                "sms_ovh_http_consumer_key": "consumer_key_test",
+                "sms_ovh_http_service_name": "sms-test-1",
                 "sms_ovh_http_from": "+33642424242",
             }
         )
@@ -28,8 +29,8 @@ class SendSmsCase(TransactionCase):
         self.assertEqual(self.account.service_name, "sms")
 
     def test_sending_sms(self):
-        with requests_mock.Mocker() as m:
-            m.get(OVH_HTTP_ENDPOINT, text="OK")
+        with patch("ovh.Client") as mock_client:
+            mock_instance = mock_client.return_value
             self.env["sms.api"]._send_sms_batch(
                 [
                     {
@@ -39,39 +40,37 @@ class SendSmsCase(TransactionCase):
                     }
                 ]
             )
-            self.assertEqual(len(m.request_history), 1)
-            params = m.request_history[0].qs
-            self.assertEqual(
-                params,
-                {
-                    "nostop": ["1"],
-                    "from": ["+33642424242"],
-                    "password": ["secret"],
-                    "message": ["alpha bravo charlie"],
-                    "to": ["+3360707070707"],
-                    "smsaccount": ["foo"],
-                    "login": ["bar"],
-                },
+            mock_client.assert_called_once_with(
+                endpoint=OVH_API_ENDPOINT,
+                application_key="app_key_test",
+                application_secret="app_secret_test",
+                consumer_key="consumer_key_test",
+            )
+            mock_instance.post.assert_called_once_with(
+                "/sms/sms-test-1/jobs",
+                message="Alpha Bravo Charlie",
+                sender="+33642424242",
+                receivers=["+3360707070707"],
+                noStopClause=True,
             )
 
     def test_partner_message_sms(self):
-        with requests_mock.Mocker() as m:
-            m.get(OVH_HTTP_ENDPOINT, text="OK")
+        with patch("ovh.Client") as mock_client:
+            mock_instance = mock_client.return_value
             partner = self.env["res.partner"].create(
                 {"name": "FOO", "mobile": "+3360707070707"}
             )
             partner._message_sms("Alpha Bravo Charlie")
-            self.assertEqual(len(m.request_history), 1)
-            params = m.request_history[0].qs
-            self.assertEqual(
-                params,
-                {
-                    "nostop": ["1"],
-                    "from": ["+33642424242"],
-                    "password": ["secret"],
-                    "message": ["alpha bravo charlie"],
-                    "to": ["+3360707070707"],
-                    "smsaccount": ["foo"],
-                    "login": ["bar"],
-                },
+            mock_client.assert_called_once_with(
+                endpoint=OVH_API_ENDPOINT,
+                application_key="app_key_test",
+                application_secret="app_secret_test",
+                consumer_key="consumer_key_test",
+            )
+            mock_instance.post.assert_called_once_with(
+                "/sms/sms-test-1/jobs",
+                message="Alpha Bravo Charlie",
+                sender="+33642424242",
+                receivers=["+3360707070707"],
+                noStopClause=True,
             )

--- a/sms_ovh_http/views/iap_account_view.xml
+++ b/sms_ovh_http/views/iap_account_view.xml
@@ -10,9 +10,10 @@
                     name="ovh"
                     attrs="{'invisible': [('provider', '!=', 'sms_ovh_http')]}"
                 >
-                    <field name="sms_ovh_http_account" />
-                    <field name="sms_ovh_http_login" />
-                    <field name="sms_ovh_http_password" />
+                    <field name="sms_ovh_http_app_key" />
+                    <field name="sms_ovh_http_app_secret" password="True" />
+                    <field name="sms_ovh_http_consumer_key" />
+                    <field name="sms_ovh_http_service_name" />
                     <field name="sms_ovh_http_from" />
                 </group>
             </xpath>


### PR DESCRIPTION
- Replace the legacy `http2sms.cgi` endpoint with the official OVH API using the `python-ovh` SDK